### PR TITLE
Added helper functions to check write settings of the app

### DIFF
--- a/PLUGIN_USAGE.MD
+++ b/PLUGIN_USAGE.MD
@@ -166,8 +166,8 @@ check if proper write settings are granted to the app
 | errorCB | <code>[errorCallback](#errorCallback)</code> | A callback function which is invoked on error. |
 
 <a name="cordova.plugins.hotspot+requestWriteSettings"></a>
-### cordova.plugins.hotspot.isAvailable(callback)
-Check if plugin is available
+### cordova.plugins.hotspot.requestWriteSettings(callback)
+open settings to request system write settings from the user
 
 **Kind**: instance method of <code>[cordova.plugins.hotspot](#cordova.plugins.hotspot)</code>  
 

--- a/PLUGIN_USAGE.MD
+++ b/PLUGIN_USAGE.MD
@@ -12,7 +12,13 @@
 <dd><p>Callback which provides the error details.</p>
 </dd>
 <dt><a href="#isAvailableCallback">isAvailableCallback</a> : <code>function</code></dt>
-<dd><p>Callback which provides the toggle Wifi info</p>
+<dd><p>Callback which checks if the plugin is available or not</p>
+</dd>
+<dt><a href="#getWriteSettingsCallback">getWriteSettingsCallback</a> : <code>function</code></dt>
+<dd><p>Callback which provides info about whether write settings are granted to the app</p>
+</dd>
+<dt><a href="#requestWriteSettingsCallback">requestWriteSettingsCallback</a> : <code>function</code></dt>
+<dd><p>Callback which is called when the app goes to settings to request write settings</p>
 </dd>
 <dt><a href="#toggleWifiCallback">toggleWifiCallback</a> : <code>function</code></dt>
 <dd><p>Callback which provides the toggle Wifi info</p>
@@ -107,6 +113,8 @@ called with an array of JSON objects.</p>
 
 * [cordova.plugins.hotspot](#cordova.plugins.hotspot) : <code>object</code>
     * [.isAvailable(callback)](#cordova.plugins.hotspot+isAvailable)
+    * [.getWriteSettings(successCB, errorCB)](#cordova.plugins.hotspot+getWriteSettings)
+    * [.requestWriteSettings(successCB, errorCB)](#cordova.plugins.hotspot+requestWriteSettings)
     * [.toggleWifi(callback, errorCB)](#cordova.plugins.hotspot+toggleWifi)
     * [.createHotspot(ssid, mode, password, successCB, errorCB)](#cordova.plugins.hotspot+createHotspot)
     * [.startHotspot(successCB, errorCB)](#cordova.plugins.hotspot+startHotspot)
@@ -145,6 +153,28 @@ Check if plugin is available
 | Param | Type | Description |
 | --- | --- | --- |
 | callback | <code>[isAvailableCallback](#isAvailableCallback)</code> | A callback function which is invoked on success. |
+
+<a name="cordova.plugins.hotspot+getWriteSettings"></a>
+### cordova.plugins.hotspot.getWriteSettings(successCB, errorCB)
+check if proper write settings are granted to the app
+
+**Kind**: instance method of <code>[cordova.plugins.hotspot](#cordova.plugins.hotspot)</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| successCB | <code>[getWriteSettingsCallback](#getWriteSettingsCallback)</code> | A callback function which is invoked on success. |
+| errorCB | <code>[errorCallback](#errorCallback)</code> | A callback function which is invoked on error. |
+
+<a name="cordova.plugins.hotspot+requestWriteSettings"></a>
+### cordova.plugins.hotspot.isAvailable(callback)
+Check if plugin is available
+
+**Kind**: instance method of <code>[cordova.plugins.hotspot](#cordova.plugins.hotspot)</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| successCB | <code>[requestWriteSettingsCallback](#requestWriteSettingsCallback)</code> | A callback function which is invoked on success. |
+| errorCB | <code>[errorCallback](#errorCallback)</code> | A callback function which is invoked on error. |
 
 <a name="cordova.plugins.hotspot+toggleWifi"></a>
 ### cordova.plugins.hotspot.toggleWifi(callback, errorCB)
@@ -724,4 +754,3 @@ A callback function to be called with Rooted information
 | Param | Type | Description |
 | --- | --- | --- |
 | isRooted, | <code>boolean</code> | true  if device is port is available, otherwise false |
-

--- a/www/HotSpotPlugin.js
+++ b/www/HotSpotPlugin.js
@@ -62,6 +62,48 @@ HotSpotPlugin.prototype = {
         }
     },
 
+    /**
+     * @callback getWriteSettingsCallback
+     * @param {boolean} settings false if no write settings, true if write settings are permitted
+     */
+
+    /**
+     * get the current write settings of the app
+     * @param  {getWriteSettingsCallback} successCB
+     *
+     * @param  {errorCallback} errorCB
+     */
+    getWriteSettings: function(successCB,errorCB) {
+        cordova.exec(
+            function(val){
+                if(val === 1)
+                    successCB(true);
+                else
+                    successCB(false);
+            },
+            errorCB,
+            'HotSpotPlugin',
+            'getWriteSettings',
+            []
+        );
+    },
+
+    /**
+     * get the current write settings of the app
+     * @param  {requestWriteSettingsCallback} successCB
+     *
+     * @param  {errorCallback} errorCB
+     */
+    requestWriteSettings: function(successCB,errorCB) {
+        cordova.exec(
+            successCB,
+            errorCB,
+            'HotSpotPlugin',
+            'requestWriteSettings',
+            []
+        );
+    },
+
 
     /**
      * Callback which provides the toggle Wifi info
@@ -135,30 +177,6 @@ HotSpotPlugin.prototype = {
         }, "HotSpotPlugin", "startHotspot", []);
     },
 
-    /**
-     * A callback function to be called when configuration was successful
-     *
-     * @callback configureHotspotCallback
-     */
-    /**
-     * Configure a running WiFi Hotspot
-     *
-     * @param {string} ssid
-     *      SSID to connect
-     * @param {string} mode
-     *      wireless mode (Open, WEP, WPA, WPA_PSK, WPA2_PSK)
-     * @param {string} password
-     *      password to use
-     * @param {configureHotspotCallback} successCB
-     *      A callback function to be called when configuration was successful
-     * @param {errorCallback} errorCB
-     *      A callback function to be called when configuration was not successful
-     */
-    configureHotspot: function (ssid, mode, password, successCB, errorCB) {
-        cordova.exec(successCB, function (err) {
-            errorCB(err);
-        }, "HotSpotPlugin", "configureHotspot", [ssid, mode, password]);
-    },
     /**
      * A callback function to be called when stop was successful
      *


### PR DESCRIPTION
makes it easier to control the flow of the app with these functions rather than having the plugin get the permissions every time a function is called
